### PR TITLE
feat(acrorn-parser): adding support for binary expression

### DIFF
--- a/src/components/Editor/Editor.data.tsx
+++ b/src/components/Editor/Editor.data.tsx
@@ -30,8 +30,12 @@ foo1();`,
 	{
 		title: 'microtasks',
 		code: `console.log(1);  
-setTimeout(() => console.log(2), 0);  
-queueMicrotask(() => console.log(3));  
+console.log(2-1);
+console.log(4*8);
+console.log(9/3);
+console.log(10%5);
+setTimeout(() => console.log(2+4), 0);  
+queueMicrotask(() => console.log(3+9));  
 Promise.resolve().then(() => {
     console.log(4);
 });   

--- a/src/utils/nodes/BinaryExpression.ts
+++ b/src/utils/nodes/BinaryExpression.ts
@@ -1,0 +1,31 @@
+import { NodeClass, NodeClassConstructor } from './Node.abstract';
+
+export class BinaryExpressionClass extends NodeClass {
+	constructor(params: NodeClassConstructor) {
+		super(params);
+	}
+
+	serialize = () => {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const binaryExpression = this.node as any;
+		const left = binaryExpression.left.value;
+		const right = binaryExpression.right.value;
+		const operator = binaryExpression.operator;
+		switch (operator) {
+			case '+':
+				return left + right;
+			case '-':
+				return left - right;
+			case '/':
+				return left / right;
+			case '*':
+				return left * right;
+			case '%':
+				return left % right;
+			default:
+				return 'operator not supported';
+		}
+	};
+
+	traverse = () => {};
+}

--- a/src/utils/nodes/factory.ts
+++ b/src/utils/nodes/factory.ts
@@ -1,16 +1,17 @@
-import { ExpressionStatementClass } from './ExpressionStatement.ts';
+import { ArrowFunctionExpressionClass } from './ArrowFunctionExpression.ts';
+import { AssignmentExpressionClass } from './AssignmentExpression.ts';
+import { BinaryExpressionClass } from './BinaryExpression.ts';
+import { BlockStatementClass } from './BlockStatement.ts';
 import { CallExpressionClass } from './CallExpression.ts';
+import { ExpressionStatementClass } from './ExpressionStatement.ts';
 import { FunctionDeclarationClass } from './FunctionDeclaration.ts';
 import { IdentifierClass } from './Identifier.ts';
-import { NotImplementedNodeClass } from './NotImplemented.ts';
-import { MemberExpressionClass } from './MemberExpression.ts';
 import { LiteralClass } from './Literal.ts';
-import { ArrowFunctionExpressionClass } from './ArrowFunctionExpression.ts';
+import { MemberExpressionClass } from './MemberExpression.ts';
 import { NodeClass, NodeClassConstructor } from './Node.abstract.ts';
-import { BlockStatementClass } from './BlockStatement.ts';
+import { NotImplementedNodeClass } from './NotImplemented.ts';
 import { ProgramClass } from './Program.ts';
 import { VariableDeclarationClass } from './VariableDeclaration.ts';
-import { AssignmentExpressionClass } from './AssignmentExpression.ts';
 
 export const nodeFactory = (params: NodeClassConstructor): NodeClass => {
 	switch (params.node.type) {
@@ -36,6 +37,8 @@ export const nodeFactory = (params: NodeClassConstructor): NodeClass => {
 			return new VariableDeclarationClass(params);
 		case 'AssignmentExpression':
 			return new AssignmentExpressionClass(params);
+		case 'BinaryExpression':
+			return new BinaryExpressionClass(params);
 		default:
 			return new NotImplementedNodeClass(params);
 	}


### PR DESCRIPTION
@vault-developer 
I know i disabled the eslint rule in BinaryExpression.ts

It wasn't my intention to do so.
I tried casting the type to BinaryExpression.
But it didn't work and led to more eslint errors.

If you know of a better approach, please let me know.